### PR TITLE
fix: eth text now centers in desktop

### DIFF
--- a/src/pages/login-page/LoginPage.styles.ts
+++ b/src/pages/login-page/LoginPage.styles.ts
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     associate: {
-      maxWidth: '280px',
+      minWidth: '280px',
       color: '#ccc',
       textDecoration: 'none',
     },


### PR DESCRIPTION
account text didnt center in desktop, now it does.